### PR TITLE
Improve pki error on file load

### DIFF
--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -230,7 +230,9 @@ impl AuraedRuntime {
         let server_crt =
             tokio::fs::read(&self.server_crt).await.with_context(|| {
                 format!(
-                    "Failed to read server certificate: {}",
+                    "Aurae requires a signed TLS certificate to run as a server, but failed to 
+                    load: '{}'. Please see https://aurae.io/certs/ for information on best 
+                    practices to quickly generate one.",
                     self.server_crt.display()
                 )
             })?;


### PR DESCRIPTION
`ERROR auraed: Err(Aurae requires a signed TLS certificate to run as a server, but failed to load: '/etc/aurae/pki/_signed.server.crt'. Please see https://aurae.io/certs/ for information on best practices to quickly generate one.`

![image](https://user-images.githubusercontent.com/3060031/213086192-2b459a6b-b2d6-4c84-9c0e-a82942793803.png)